### PR TITLE
Optional external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ External Dependencies:
   All platforms: ```conda install -c conda-forge  IPOPT```
   Windows: [IPOPT releases page](https://github.com/coin-or/Ipopt/releases)
   Mac/Linux: [Compile using coinbrew](https://coin-or.github.io/Ipopt/INSTALL.html#COINBREW)
-- libhsl with ma57 within library loading path (Requires a free academic or paid industrial license)
+- (optional) libhsl with ma57 within library loading path (Requires a free academic or paid industrial license)
 
 To use,
 1) Download this repository via ```git clone``` or manually using the download zip button at the top of the page.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ A variety of plotting tools for models created with pyphi.
 Dependencies:
 numpy, scipy, pandas, xlrd, bokeh, matplotlib, pyomo
 
-External Dependencies:
-- IPOPT as an executable in system path
+Optional External Dependencies:
+- IPOPT as an executable in system path (Solves remotely via the NEOS server if local executable is not available)
   All platforms: ```conda install -c conda-forge  IPOPT```
   Windows: [IPOPT releases page](https://github.com/coin-or/Ipopt/releases)
   Mac/Linux: [Compile using coinbrew](https://coin-or.github.io/Ipopt/INSTALL.html#COINBREW)
-- (optional) libhsl with ma57 within library loading path (Requires a free academic or paid industrial license)
+- libhsl with ma57 within library loading path (Speeds up IPOPT for large problems but requires a free academic or paid industrial license)
 
 To use,
 1) Download this repository via ```git clone``` or manually using the download zip button at the top of the page.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,27 @@ Dependencies:
 numpy, scipy, pandas, xlrd, bokeh, matplotlib, pyomo
 
 External Dependencies:
-- ipopt as an executable in system path
-- libhsl with ma57
+- IPOPT as an executable in system path
+  All platforms: ```conda install -c conda-forge  IPOPT```
+  Windows: [IPOPT releases page](https://github.com/coin-or/Ipopt/releases)
+  Mac/Linux: [Compile using coinbrew](https://coin-or.github.io/Ipopt/INSTALL.html#COINBREW)
+- libhsl with ma57 within library loading path (Requires a free academic or paid industrial license)
+
+To use,
+1) Download this repository via ```git clone``` or manually using the download zip button at the top of the page.
+2) Install python dependencies using either ```pip install -r requirements.txt``` or ```conda install -c conda-forge -file requirements```. You may wish to create a new virtual environment using conda or venv before installing.
+3) Add pyphi to your python path so it can be imported in python code
+	Windows: In the cmd terminal enter ```set PYTHONPATH=C:\Path\To\pyphi;%PYTHONPATH%``` to  set for that session or ```setx PYTHONPATH C:\Path\To\pyphi;%PYTHONPATH%``` to set it system wide.
+	Mac/Linux: In the terminal, use ```export PYTHONPATH=/path/to/pyphi:$PYTHONPATH``` to set for that session or add to your *rc/profile file to automatically set it.
+	Using conda: After you have activated your virtual environment via ```conda activate yourenv```, call ```conda env config vars set PYTHONPATH==C:\Path\To\pyphi;%PYTHONPATH%``` (Windows) or ```conda env config vars set PYTHONPATH==C:\Path\To\pyphi;%PYTHONPATH%``` (Mac/Linux). Then reactivate your environment with ```conda activate yourenv``` . This will update your PYTHONPATH automatically within your environment.
+4) Download listed external dependencies, putting libhsl into the same directory as IPOPT. Then add to path
+	Windows: ```set PATH=C:\Path\To\ipopt;%PATH%```
+	Mac/Linux: ```export PATH=/path/to/ipopt:$PATH```
+	Using conda: Use the OS specific command with ```conda env config vars set``` as in step 3 to automatically set each time.
+
+To confirm you have a working installation, copy the file ```Examples/Example_Script_testing_MD_by_NLP.py``` to a new directory, run it using ```python Example_Script_testing_MD_by_NLP.py```, and verity that there are no errors logged to the console.
 
 =============================================
 What is New Release March 30th.
 
 * PCA model estimation using Non-linear programming as described in Lopez-Negrete et al. J. Chemometrics 2010; 24: 301–311
-

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ A variety of plotting tools for models created with pyphi.
 ==========================================
 
 Dependencies:
-numpy, scipy, pandas, datetime, bokeh , matplotlib, pyomo
+numpy, scipy, pandas, xlrd, bokeh, matplotlib, pyomo
 
+External Dependencies:
+- ipopt as an executable in system path
+- libhsl with ma57
 
 =============================================
 What is New Release March 30th.

--- a/pyphi.py
+++ b/pyphi.py
@@ -29,8 +29,12 @@ try:
     pyomo_ok = True
 except ImportError:
     pyomo_ok = False
- 
- 
+
+# check if we have libhsl availble to use as IPOPT's linear solver
+from ctypes.util import find_library
+hsl_ok = ipopt_ok and find_library('libhsl')
+
+
 def pca (X,A,*,mcs=True,md_algorithm='nipals',force_nipals=False,shush=False,cross_val=0):
     """ Principal Components Analysis routine
     
@@ -432,19 +436,23 @@ def pca_(X,A,*,mcs=True,md_algorithm='nipals',force_nipals=False,shush=False):
                 else:
                     return Constraint.Skip
             model.c20c = Constraint(model.A, model.A, rule=_20c_con)
-                
+
             # Constraints 20d
             def mean_zero(model,i):
                 return sum (model.T[o,i]  for o in model.O )==0
             model.eq3 = Constraint(model.A,rule=mean_zero)
-                  
+
             def _eq_20a_obj(model):
                 return sum(sum((model.X[o,n]- model.psi[o,n] * sum(model.T[o,a] * model.P[n,a] for a in model.A))**2 for n in model.N) for o in model.O)
             model.obj = Objective(rule=_eq_20a_obj)
             
             solver = SolverFactory('ipopt')
-            solver.options['linear_solver']='ma57'
-            results=solver.solve(model,tee=True)   
+            if (hsl_ok):
+                print("libhsl found. Using ma57 with IPOPT")
+                # TODO: This assumes user's libhsl has ma57. Personal licences may not.
+                solver.options['linear_solver'] = 'ma57'
+            results=solver.solve(model,tee=True)
+
             T=[]
             for o in model.O:
                  t=[]

--- a/pyphi.py
+++ b/pyphi.py
@@ -30,6 +30,15 @@ try:
 except ImportError:
     pyomo_ok = False
 
+# check if an ipopt binary is accessable
+# shutil was introduced in Python 3.2
+from shutil import which
+if (which('ipopt')):
+    ipopt_ok = True
+else:
+    ipopt_ok = False
+    print("IPOPT exectuable not found in path. Using NEOS server instead.")
+
 # check if we have libhsl availble to use as IPOPT's linear solver
 from ctypes.util import find_library
 hsl_ok = ipopt_ok and find_library('libhsl')
@@ -445,13 +454,17 @@ def pca_(X,A,*,mcs=True,md_algorithm='nipals',force_nipals=False,shush=False):
             def _eq_20a_obj(model):
                 return sum(sum((model.X[o,n]- model.psi[o,n] * sum(model.T[o,a] * model.P[n,a] for a in model.A))**2 for n in model.N) for o in model.O)
             model.obj = Objective(rule=_eq_20a_obj)
-            
-            solver = SolverFactory('ipopt')
-            if (hsl_ok):
-                print("libhsl found. Using ma57 with IPOPT")
-                # TODO: This assumes user's libhsl has ma57. Personal licences may not.
-                solver.options['linear_solver'] = 'ma57'
-            results=solver.solve(model,tee=True)
+
+            if (ipopt_ok):
+                solver = SolverFactory('ipopt')
+                if (hsl_ok):
+                    print("libhsl found. Using ma57 with IPOPT")
+                    # TODO: This assumes user's libhsl has ma57. Personal licences may not.
+                    solver.options['linear_solver'] = 'ma57'
+                results = solver.solve(model,tee=True)
+            else:
+                solver_manager = SolverManagerFactory('neos')
+                results = solver_manager.solve(model, opt='ipopt', tee=True)
 
             T=[]
             for o in model.O:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+scipy
+pandas
+xlrd
+bokeh
+matplotlib
+pyomo


### PR DESCRIPTION
Make having IPOPT installed and MA57 as optional dependencies so pyPhi is now "batteries included". Without either, IPOPT is used on the NEOS remote server to solve the problem. If IPOPT is available, but libhsl is not found, use the default MUMPS linear solver instead of MA57.
