### PR TITLE
Addition of try/catch to ma57_dummy_check and Ability to send pca and pls results to a specified directory

### DIFF
--- a/pyphi.py
+++ b/pyphi.py
@@ -93,6 +93,11 @@ if pyomo_ok and ipopt_ok:
       ma57_ok = ma57_dummy_check()
     except Exception:
       ma57_ok = False
+      print('---------------------------------------------------------------------')
+      print("        Error indicates MA57 not available to IPOPT")
+      print("  But pyphi can still be used; IPOPT will use default solver Mumps ")
+      print('---------------------------------------------------------------------')
+
 else:
     ma57_ok = False
 

--- a/pyphi.py
+++ b/pyphi.py
@@ -89,7 +89,10 @@ def ma57_dummy_check():
     return ma57_ok
 
 if pyomo_ok and ipopt_ok:
-    ma57_ok = ma57_dummy_check()
+    try:
+      ma57_ok = ma57_dummy_check()
+    except Exception:
+      ma57_ok = False
 else:
     ma57_ok = False
 

--- a/pyphi.py
+++ b/pyphi.py
@@ -102,7 +102,7 @@ else:
     ma57_ok = False
 
 
-def pca (X,A,*,mcs=True,md_algorithm='nipals',force_nipals=False,shush=False,cross_val=0):
+def pca (X,A,*,mcs=True,md_algorithm='nipals',force_nipals=False,shush=False,cross_val=0,mdlname='.'):
     """ Principal Components Analysis routine
     
     by Salvador Garcia-Munoz 
@@ -132,6 +132,9 @@ def pca (X,A,*,mcs=True,md_algorithm='nipals',force_nipals=False,shush=False,cro
                    element wise removing cross_val% of the data every round
                    
                    if ==   0:  Bypass cross-validation  *default if not sent*
+                   
+        mdlname: Name associated with model, default is '.'
+        
     Output:
         A dictionary with all PCA loadings, scores and other diagnostics.
     
@@ -274,6 +277,9 @@ def pca (X,A,*,mcs=True,md_algorithm='nipals',force_nipals=False,shush=False,cro
             print('--------------------------------------------------------------')        
     else:
         pcaobj='Cannot cross validate  with those options'
+        
+    pcaobj['mdlname'] = mdlname    
+        
     return pcaobj
 
 def pca_(X,A,*,mcs=True,md_algorithm='nipals',force_nipals=False,shush=False):
@@ -618,7 +624,7 @@ def pca_(X,A,*,mcs=True,md_algorithm='nipals',force_nipals=False,shush=False):
             pca_obj=1
             return pca_obj
   
-def pls(X,Y,A,*,mcsX=True,mcsY=True,md_algorithm='nipals',force_nipals=False,shush=False,cross_val=0,cross_val_X=False):
+def pls(X,Y,A,*,mcsX=True,mcsY=True,md_algorithm='nipals',force_nipals=False,shush=False,cross_val=0,cross_val_X=False,mdlname='.'):
     """ Projection to  Latent Structures routine
     
     by Salvador Garcia-Munoz 
@@ -649,6 +655,8 @@ def pls(X,Y,A,*,mcsX=True,mcsY=True,md_algorithm='nipals',force_nipals=False,shu
                    
         cross_val_X: 'True' : Calculates Q2 values for the X and Y matrices
                      'False': Cross-validation strictly on Y matrix *default if not sent*
+                     
+        mdlname: Name associated with model, default is '.'
     
     Output:
         A dictionary with all PLS loadings, scores and other diagnostics.
@@ -1138,6 +1146,9 @@ def pls(X,Y,A,*,mcsX=True,mcsY=True,md_algorithm='nipals',force_nipals=False,shu
                 print('-------------------------------------------------------------------------------------------------------')   
     else:
         plsobj='Cannot cross validate  with those options'
+        
+    plsobj['mdlname'] = mdlname    
+        
     return plsobj    
         
 def pls_(X,Y,A,*,mcsX=True,mcsY=True,md_algorithm='nipals',force_nipals=False,shush=False):

--- a/pyphi_helperfns.py
+++ b/pyphi_helperfns.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Helper functions for pyphi
+"""
+
+import os
+
+def create_resdir(mdlname):
+    """
+    Create a directory to store the results of model 'mdlname'. If the directory
+    already exists, a message will alert that the directory exists and will not
+    delete the directory
+
+    Parameters
+    ----------
+    mdlname : str name given to a model when running pca or pls
+
+    Returns
+    -------
+    None.
+
+    """
+    if os.path.isdir(mdlname):
+        print('Directory ',mdlname,' already exists, choose another name')
+        return
+    else:
+        os.mkdir(mdlname)
+    return    
+
+

--- a/pyphi_plots.py
+++ b/pyphi_plots.py
@@ -79,7 +79,7 @@ def r2pv(mvmobj,*,plotwidth=600,plotheight=400):
     
     if is_pls:
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("r2xypv_"+rnd_num+".html",title="R2XYPV") 
+        output_file(mvmobj['mdlname']+'/'+"r2xypv_"+rnd_num+".html",title="R2XYPV") 
         colormap =cm.get_cmap("rainbow")
         different_colors=A
         color_mapping=colormap(np.linspace(0,1,different_colors),1,True)
@@ -110,7 +110,7 @@ def r2pv(mvmobj,*,plotwidth=600,plotheight=400):
         
     else:   
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("r2xpv_"+rnd_num+".html",title='R2XPV') 
+        output_file(mvmobj['mdlname']+'/'+"r2xpv_"+rnd_num+".html",title='R2XPV') 
         colormap =cm.get_cmap("rainbow")
         different_colors=A
         color_mapping=colormap(np.linspace(0,1,different_colors),1,True)
@@ -184,7 +184,7 @@ def loadings(mvmobj,*,plotwidth=600):
       
     if is_pls:
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("Loadings X Space_"+rnd_num+".html",title='X Loadings PLS')
+        output_file(mvmobj['mdlname']+'/'+"Loadings X Space_"+rnd_num+".html",title='X Loadings PLS')
         for i in list(np.arange(A)):
             p = figure(x_range=XVar, title="X Space Loadings "+lv_labels[i],
                     tools=TOOLS,tooltips=TOOLTIPS,plot_width=plotwidth)
@@ -203,7 +203,7 @@ def loadings(mvmobj,*,plotwidth=600):
                 p_list.append(p)
         show(column(p_list))    
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("Loadings Y Space_"+rnd_num+".html",title='Y Loadings PLS')
+        output_file(mvmobj['mdlname']+'/'+"Loadings Y Space_"+rnd_num+".html",title='Y Loadings PLS')
         for i in list(np.arange(A)):
             p = figure(x_range=YVar, title="Y Space Loadings "+lv_labels[i],
                     tools="save,box_zoom,pan,reset",tooltips=TOOLTIPS,plot_width=plotwidth)
@@ -223,7 +223,7 @@ def loadings(mvmobj,*,plotwidth=600):
         show(column(p_list))
     else:   
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("Loadings X Space_"+rnd_num+".html",title='X Loadings PCA') 
+        output_file(mvmobj['mdlname']+'/'+"Loadings X Space_"+rnd_num+".html",title='X Loadings PCA') 
         for i in list(np.arange(A)):
             source1 = ColumnDataSource(data=dict(x_=XVar, y_=mvmobj['P'][:,i].tolist(),names=XVar))  
             
@@ -276,7 +276,7 @@ def loadings_map(mvmobj,dims,*,plotwidth=600):
                 YVar.append('YVar #'+str(n))               
     
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("Loadings Map"+rnd_num+".html",title='Loadings Map')
+        output_file(mvmobj['mdlname']+'/'+"Loadings Map"+rnd_num+".html",title='Loadings Map')
        
     
         x_ws = mvmobj['Ws'][:,dims[0]-1]
@@ -328,7 +328,7 @@ def loadings_map(mvmobj,dims,*,plotwidth=600):
             for n in list(np.arange(num_varX)+1):
                 XVar.append('XVar #'+str(n))                   
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("Loadings Map"+rnd_num+".html",title='Loadings Map')    
+        output_file(mvmobj['mdlname']+'/'+"Loadings Map"+rnd_num+".html",title='Loadings Map')    
         x_p = mvmobj['P'][:,dims[0]-1]
         y_p = mvmobj['P'][:,dims[1]-1]                        
         TOOLS = "save,wheel_zoom,box_zoom,pan,reset,box_select,lasso_select"
@@ -406,7 +406,7 @@ def weighted_loadings(mvmobj,*,plotwidth=600):
     
     if is_pls:
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("Loadings X Space_"+rnd_num+".html",title='X Weighted Loadings PLS')
+        output_file(mvmobj['mdlname']+'/'+"Loadings X Space_"+rnd_num+".html",title='X Weighted Loadings PLS')
         for i in list(np.arange(A)):
             p = figure(x_range=XVar, title="X Space Weighted Loadings "+lv_labels[i],
                      tools=TOOLS,tooltips=TOOLTIPS,plot_width=plotwidth)
@@ -425,7 +425,7 @@ def weighted_loadings(mvmobj,*,plotwidth=600):
                 p_list.append(p)
         show(column(p_list)) 
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("Loadings Y Space_"+rnd_num+".html",title='Y Weighted Loadings PLS')
+        output_file(mvmobj['mdlname']+'/'+"Loadings Y Space_"+rnd_num+".html",title='Y Weighted Loadings PLS')
         for i in list(np.arange(A)):
             p = figure(x_range=YVar, title="Y Space Weighted Loadings "+lv_labels[i],
                      tools=TOOLS,tooltips=TOOLTIPS,plot_width=plotwidth)
@@ -445,7 +445,7 @@ def weighted_loadings(mvmobj,*,plotwidth=600):
         show(column(p_list))
     else:   
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("Loadings X Space_"+rnd_num+".html",title='X Weighted Loadings PCA') 
+        output_file(mvmobj['mdlname']+'/'+"Loadings X Space_"+rnd_num+".html",title='X Weighted Loadings PCA') 
         for i in list(np.arange(A)):
             p = figure(x_range=XVar, title="X Space Weighted Loadings "+lv_labels[i],
                      tools=TOOLS,tooltips=TOOLTIPS,plot_width=plotwidth)
@@ -476,7 +476,7 @@ def vip(mvmobj,*,plotwidth=600):
     
     if 'Q' in mvmobj:  
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("VIP_"+rnd_num+".html",title='VIP Coefficient') 
+        output_file(mvmobj['mdlname']+'/'+"VIP_"+rnd_num+".html",title='VIP Coefficient') 
         num_varX=mvmobj['P'].shape[0]            
         if 'varidX' in mvmobj:
             XVar=mvmobj['varidX']
@@ -548,7 +548,7 @@ def score_scatter(mvmobj,xydim,*,CLASSID=False,colorby=False,Xnew=False,add_ci=F
     
     if isinstance(CLASSID,np.bool): # No CLASSIDS
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("Score_Scatter_"+rnd_num+".html",title='Score Scatter t['+str(xydim[0])+'] - t['+str(xydim[1])+ ']')
+        output_file(mvmobj['mdlname']+'/'+"Score_Scatter_"+rnd_num+".html",title='Score Scatter t['+str(xydim[0])+'] - t['+str(xydim[1])+ ']')
 
         x_=T_matrix[:,[xydim[0]-1]]
         y_=T_matrix[:,[xydim[1]-1]]
@@ -596,7 +596,7 @@ def score_scatter(mvmobj,xydim,*,CLASSID=False,colorby=False,Xnew=False,add_ci=F
         color_mapping=colormap(np.linspace(0,1,different_colors),1,True)
         bokeh_palette=["#%02x%02x%02x" % (r, g, b) for r, g, b in color_mapping[:,0:3]]  
         rnd_num=str(int(np.round(1000*np.random.random_sample())))               
-        output_file("Score_Scatter_"+rnd_num+".html",title='Score Scatter t['+str(xydim[0])+'] - t['+str(xydim[1])+ ']') 
+        output_file(mvmobj['mdlname']+'/'+"Score_Scatter_"+rnd_num+".html",title='Score Scatter t['+str(xydim[0])+'] - t['+str(xydim[1])+ ']') 
         x_=T_matrix[:,[xydim[0]-1]]
         y_=T_matrix[:,[xydim[1]-1]]          
         
@@ -716,7 +716,7 @@ def score_line(mvmobj,dim,*,CLASSID=False,colorby=False,Xnew=False,add_ci=False,
                        
     if isinstance(CLASSID,np.bool): # No CLASSIDS
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("Score_Line_"+rnd_num+".html",title='Score Line t['+str(dim[0])+ ']')
+        output_file(mvmobj['mdlname']+'/'+"Score_Line_"+rnd_num+".html",title='Score Line t['+str(dim[0])+ ']')
 
         y_=T_matrix[:,[dim[0]-1]]
         x_=list(range(1,y_.shape[0]+1))
@@ -754,7 +754,7 @@ def score_line(mvmobj,dim,*,CLASSID=False,colorby=False,Xnew=False,add_ci=False,
         color_mapping=colormap(np.linspace(0,1,different_colors),1,True)
         bokeh_palette=["#%02x%02x%02x" % (r, g, b) for r, g, b in color_mapping[:,0:3]]  
         rnd_num=str(int(np.round(1000*np.random.random_sample())))               
-        output_file("Score_Line_"+rnd_num+".html",title='Score Line t['+str(dim[0])+ ']') 
+        output_file(mvmobj['mdlname']+'/'+"Score_Line_"+rnd_num+".html",title='Score Line t['+str(dim[0])+ ']') 
 
         y_=T_matrix[:,[dim[0]-1]]  
         x_=list(range(1,y_.shape[0]+1))        
@@ -942,7 +942,7 @@ def diagnostics(mvmobj,*,Xnew=False,Ynew=False,score_plot_xydim=False,plotwidth=
             ]
     
     rnd_num=str(int(np.round(1000*np.random.random_sample())))               
-    output_file("Diagnostics"+rnd_num+".html",title='Diagnostics') 
+    output_file(mvmobj['mdlname']+'/'+"Diagnostics"+rnd_num+".html",title='Diagnostics') 
     p = figure(tools=TOOLS, tooltips=TOOLTIPS, plot_width=plotwidth, title="Hotelling's T2")
     p.circle('x','t2',source=source)
     if ht2_logscale:
@@ -1100,7 +1100,7 @@ def predvsobs(mvmobj,X,Y,*,CLASSID=False,colorby=False,x_space=False):
     
     if isinstance(CLASSID,np.bool): # No CLASSIDS
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("ObsvsPred_"+rnd_num+".html",title='ObsvsPred')
+        output_file(mvmobj['mdlname']+'/'+"ObsvsPred_"+rnd_num+".html",title='ObsvsPred')
         plot_counter=0
         
         if not(isinstance(yhat,np.bool)): #skip if PCA model sent
@@ -1150,7 +1150,7 @@ def predvsobs(mvmobj,X,Y,*,CLASSID=False,colorby=False,x_space=False):
         color_mapping=colormap(np.linspace(0,1,different_colors),1,True)
         bokeh_palette=["#%02x%02x%02x" % (r, g, b) for r, g, b in color_mapping[:,0:3]]  
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("ObsvsPred_"+rnd_num+".html",title='ObsvsPred')      
+        output_file(mvmobj['mdlname']+'/'+"ObsvsPred_"+rnd_num+".html",title='ObsvsPred')      
         classid_=list(CLASSID[colorby])
         
         plot_counter=0
@@ -1302,7 +1302,7 @@ def contributions_plot(mvmobj,X,cont_type,*,Y=False,from_obs=False,to_obs=False,
             XVar.append('XVar #'+str(n))               
 
     rnd_num=str(int(np.round(1000*np.random.random_sample())))
-    output_file("Contributions"+rnd_num+".html",title='Contributions')
+    output_file(mvmobj['mdlname']+'/'+"Contributions"+rnd_num+".html",title='Contributions')
     if isinstance(from_obs,list):
         from_txt=", ".join(map(str, from_obs))
         from_txt=" from obs: "+from_txt
@@ -1472,7 +1472,7 @@ def mb_weights(mvmobj,*,plotwidth=600,plotheight=400):
     XVar=mvmobj['Xblocknames']        
     for i in list(np.arange(A)):
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("blockweights_"+rnd_num+".html",title="Block Weights")         
+        output_file(mvmobj['mdlname']+'/'+"blockweights_"+rnd_num+".html",title="Block Weights")         
         px = figure(x_range=XVar, title="Block weights for MBPLS"+lv_labels[i],
              tools="save,box_zoom,hover,reset", tooltips=[("Var:","@x_")],plot_width=plotwidth,plot_height=plotheight)   
         source1 = ColumnDataSource(data=dict(x_=XVar, y_=mvmobj['Wt'][:,i].tolist(),names=XVar)) 
@@ -1513,7 +1513,7 @@ def mb_r2pb(mvmobj,*,plotwidth=600,plotheight=400):
     for i in list(np.arange(A)):
         r2pbX_dict.update({lv_labels[i] : mvmobj['r2pbX'][:,i].tolist()})
         rnd_num=str(int(np.round(1000*np.random.random_sample())))
-        output_file("r2perblock"+rnd_num+".html",title="R2 per Block") 
+        output_file(mvmobj['mdlname']+'/'+"r2perblock"+rnd_num+".html",title="R2 per Block") 
         colormap =cm.get_cmap("rainbow")
         different_colors=A
         color_mapping=colormap(np.linspace(0,1,different_colors),1,True)
@@ -1558,7 +1558,7 @@ def mb_vip(mvmobj,*,plotwidth=600,plotheight=400):
     XVar = XVar_
     vip=vip[index]
     rnd_num=str(int(np.round(1000*np.random.random_sample())))
-    output_file("blockvip"+rnd_num+".html",title="Block VIP") 
+    output_file(mvmobj['mdlname']+'/'+"blockvip"+rnd_num+".html",title="Block VIP") 
     source1 = ColumnDataSource(data=dict(x_=XVar, y_=vip.tolist(),names=XVar))         
     px = figure(x_range=XVar, title="Block VIP for MBPLS",
          tools="save,box_zoom,hover,reset",tooltips=[("Block:","@x_")],plot_width=plotwidth,plot_height=plotheight)   


### PR DESCRIPTION
I got the following error when importing pyphi
<img width="603" alt="error_import_pyphi" src="https://user-images.githubusercontent.com/7705554/123500795-96a1bb80-d60e-11eb-8985-c287617e7961.png">
this happens because when ma57 is not found, ipopt throws a error and halts. So I have put a try/catch statement in ma57_dummy_check function. Also, even with that it will show an error message that solver is not found. Since it could be confusing for a user whether pyphi is loaded properly or not, I added a clarifying message. With the proposed changes, for a user not having ma57, they will see the output below when importing pyphi
<img width="532" alt="message_import_pyphi" src="https://user-images.githubusercontent.com/7705554/123500843-e8e2dc80-d60e-11eb-877b-4072077b66ae.png">
