### PR TITLE
Allow `import pyphi`

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .pyphi import *


### PR DESCRIPTION
Without this, you need to do `import pyphi.pyphi`